### PR TITLE
add support for more params

### DIFF
--- a/README.org
+++ b/README.org
@@ -30,8 +30,12 @@ Alpha. Safe to use, but feature-poor. It's still better than it not existing at 
 
 Each block supports the following arguments:
 
-| Argument | Description    | Example                     | Default |
-|----------+----------------+-----------------------------+---------|
-| =:db=      | Database name. | =#+BEGIN_SRC mongo :db staff= | None.   |
+| Argument     | Description      | Example                                 | Default |
+|--------------+------------------+-----------------------------------------+---------|
+| =:db=        | Database name.   | =#+BEGIN_SRC mongo :db staff=           | None.   |
+| =:port=      | Port             | =#+BEGIN_SRC mongo :port 27018=         | None.   |
+| =:user=      | Username         | =#+BEGIN_SRC mongo :user root=          | None.   |
+| =:password=  | Password         | =#+BEGIN_SRC mongo :password superword= | None.   |
+| =:mongoexec= | Mongo executable | =#+BEGIN_SRC mongo :mongoexec mongo26=  | "mongo" |
 
 All defaults are customizable with =M-x customize-group RET ob-mongo=.


### PR DESCRIPTION
Hi, thank you for this. I used it a lot in the last days. Sometimes I need switch versions of mongodb and have some running on different ports. So I added more parameters. Maybe you find it useful, too.
