### PR TITLE
Remove (require 'org) from ob-mongo.el

### DIFF
--- a/ob-mongo.el
+++ b/ob-mongo.el
@@ -14,7 +14,6 @@
 ;; Execute mongodb queries within org-mode blocks.
 
 ;;; Code:
-(require 'org)
 (require 'ob)
 
 (defgroup ob-mongo nil


### PR DESCRIPTION
This causes a recursive load error between org.elc and
ob-mongo.elc. Removing this line means that I can use ob-mongo
successfully.