### PR TITLE
added authdb flag

### DIFF
--- a/README.org
+++ b/README.org
@@ -30,13 +30,14 @@ Alpha. Safe to use, but feature-poor. It's still better than it not existing at 
 
 Each block supports the following arguments:
 
-| Argument   | Description      | Example                               | Default |
-|------------+------------------+---------------------------------------+---------|
-| =:db=        | Database name.   | =#+BEGIN_SRC mongo :db staff=           | None.   |
-| =:host=      | Host             | =#+BEGIN_SRC mongo :host localhost=     | None.   |
-| =:port=      | Port             | =#+BEGIN_SRC mongo :port 27018=         | None.   |
-| =:user=      | Username         | =#+BEGIN_SRC mongo :user root=          | None.   |
-| =:password=  | Password         | =#+BEGIN_SRC mongo :password superword= | None.   |
-| =:mongoexec= | Mongo executable | =#+BEGIN_SRC mongo :mongoexec mongo26=  | "mongo" |
+| Argument     | Description             | Example                                 | Default |
+|--------------+-------------------------+-----------------------------------------+---------|
+| =:db=        | Database name.          | =#+BEGIN_SRC mongo :db staff=           | None.   |
+| =:host=      | Host                    | =#+BEGIN_SRC mongo :host localhost=     | None.   |
+| =:port=      | Port                    | =#+BEGIN_SRC mongo :port 27018=         | None.   |
+| =:user=      | Username                | =#+BEGIN_SRC mongo :user root=          | None.   |
+| =:password=  | Password                | =#+BEGIN_SRC mongo :password superword= | None.   |
+| =:authdb=    | Authentication database | =#+BEGIN_SRC mongo :authdb admin=       | None.   |
+| =:mongoexec= | Mongo executable        | =#+BEGIN_SRC mongo :mongoexec mongo26=  | "mongo" |
 
 All defaults are customizable with =M-x customize-group RET ob-mongo=.

--- a/ob-mongo.el
+++ b/ob-mongo.el
@@ -47,6 +47,11 @@
   :group 'ob-mongo
   :type 'string)
 
+(defcustom ob-mongo:default-authdb nil
+  "Default authentication database."
+  :group 'ob-mongo
+  :type 'string)
+
 (defcustom ob-mongo:default-mongo-executable "mongo"
   "Default mongo executable."
   :group 'ob-mongo
@@ -59,6 +64,7 @@
                  (:port ,ob-mongo:default-port "--port")
                  (:password ,ob-mongo:default-password "--password")
                  (:user ,ob-mongo:default-user "--username")
+                 (:authdb ,ob-mongo:default-authdb "--authenticationDatabase")
                  (:db ,ob-mongo:default-db))))
     (mapconcat (lambda (pdef)
                  (let ((opt (or (nth 2 pdef) ""))


### PR DESCRIPTION
I added a parameter to authenticate with a particular database using the `--authenticationDatabase` flag. Without it, the db parameter needed to be the authentication database and the database we wished to query would need to be specified in the code block with: `use mydb;`.

P.S. Thanks for this package, it's very handy!